### PR TITLE
Add save/load methods to kNN class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cell-neighbors"
-version = "0.1.0"
+version = "0.2.0rc0"
 description = "voyager-based kNN for single-cell data"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cell-neighbors"
-version = "0.2.0rc0"
+version = "0.2.0"
 description = "voyager-based kNN for single-cell data"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Add `save(path)` method to persist kNN index and metadata to disk
- Add `load(path, adata)` class method to restore a saved index
- Bump version to 0.2.0rc0

## Test plan
- [ ] Create a kNN instance and call `save()` to verify files are created
- [ ] Call `kNN.load()` and verify the index is restored correctly
- [ ] Run queries on loaded index to confirm functionality matches original

🤖 Generated with [Claude Code](https://claude.com/claude-code)